### PR TITLE
refactor: switch to profile com.github.generic-trust-anchor-api.basic.signature

### DIFF
--- a/demo/cmp/send_cr_cmp_message.sh
+++ b/demo/cmp/send_cr_cmp_message.sh
@@ -33,7 +33,7 @@ openssl cmp -server pki.certificate.fi:8700/pkix/ -secret pass:insta -recipient 
 export OPENSSL_CONF=../openssl_config/openssl.cnf
 
 echo "Store issued cert"
-gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.tls --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Test Cert" --attr_val="$CMP_CREDENTIAL_DIR/test.cert.pem"
+gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Test Cert" --attr_val="$CMP_CREDENTIAL_DIR/test.cert.pem"
 
 echo "List the stored attributes"
 gta-cli personality_attributes_enumerate --pers=CMP

--- a/demo/cmp/send_kur_cmp_message.sh
+++ b/demo/cmp/send_kur_cmp_message.sh
@@ -29,7 +29,7 @@ fi
 
 echo "Create reference to GTA API public key for OpenSSL provider (personality_name,profile_name)"
 echo "-----BEGIN GTA TRUSTED KEY-----" > "$CMP_CREDENTIAL_DIR/gta-trusted-cert.pem"
-echo -n "CMP,com.github.generic-trust-anchor-api.basic.tls" | base64 >> "$CMP_CREDENTIAL_DIR/gta-trusted-cert.pem"
+echo -n "CMP,com.github.generic-trust-anchor-api.basic.signature" | base64 >> "$CMP_CREDENTIAL_DIR/gta-trusted-cert.pem"
 echo "-----END GTA TRUSTED KEY-----" >> "$CMP_CREDENTIAL_DIR/gta-trusted-cert.pem"
 cat "$CMP_CREDENTIAL_DIR/gta-trusted-cert.pem"
 echo ""
@@ -37,13 +37,13 @@ echo ""
 export OPENSSL_CONF=../openssl_config/openssl.cnf
 
 echo "Remove old trusted certificate"
-gta-cli personality_remove_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.tls --attr_name="Trusted"
+gta-cli personality_remove_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_name="Trusted"
 
 echo "Get Insta CA certificate"
 wget 'http://pki.certificate.fi:8081/install-ca-cert.html/ca-certificate.crt?ca-id=632&download-certificate=1' -O "$CMP_CREDENTIAL_DIR/insta.ca.crt"
 
 echo "Add trusted certificate to personality"
-gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.tls --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Trusted" --attr_val="$CMP_CREDENTIAL_DIR/insta.ca.crt"
+gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Trusted" --attr_val="$CMP_CREDENTIAL_DIR/insta.ca.crt"
 
 echo "List the stored attributes (after the root CA install)"
 gta-cli personality_attributes_enumerate --pers=CMP
@@ -59,13 +59,13 @@ echo "List the stored attributes (before remove)"
 gta-cli personality_attributes_enumerate --pers=CMP
 
 echo "Remove old certificate"
-gta-cli personality_remove_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.tls --attr_name="Test Cert"
+gta-cli personality_remove_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_name="Test Cert"
 
 echo "List the stored attributes (after remove)"
 gta-cli personality_attributes_enumerate --pers=CMP
 
 echo "Add new certificate to personality"
-gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.tls --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Test Cert" --attr_val="$CMP_CREDENTIAL_DIR/test.cert.pem"
+gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Test Cert" --attr_val="$CMP_CREDENTIAL_DIR/test.cert.pem"
 
 echo "List the stored attributes (new)"
 gta-cli personality_attributes_enumerate --pers=CMP

--- a/demo/prepare_cmp_demo.sh
+++ b/demo/prepare_cmp_demo.sh
@@ -43,7 +43,7 @@ rm -f "$CMP_CREDENTIAL_DIR/"*
 
 echo "Create reference to GTA API private key for OpenSSL provider (personality_name,profile_name)"
 echo "-----BEGIN GTA PRIVATE KEY-----" > "$CMP_CREDENTIAL_DIR/gta-key.pem"
-echo -n "CMP,com.github.generic-trust-anchor-api.basic.tls" | base64 >> "$CMP_CREDENTIAL_DIR/gta-key.pem"
+echo -n "CMP,com.github.generic-trust-anchor-api.basic.signature" | base64 >> "$CMP_CREDENTIAL_DIR/gta-key.pem"
 echo "-----END GTA PRIVATE KEY-----" >> "$CMP_CREDENTIAL_DIR/gta-key.pem"
 cat "$CMP_CREDENTIAL_DIR/gta-key.pem"
 echo ""

--- a/demo/prepare_demo.sh
+++ b/demo/prepare_demo.sh
@@ -85,10 +85,10 @@ fi
 
 echo "Update GTA personality for client in the gta-key.pem"
 echo "-----BEGIN GTA PRIVATE KEY-----" >./client/gta-key.pem
-# b64(pers_dilithium2_default,com.github.generic-trust-anchor-api.basic.tls)
+# b64(pers_dilithium2_default,com.github.generic-trust-anchor-api.basic.signature)
 # or
-# b64(pers_ec_default,com.github.generic-trust-anchor-api.basic.tls)
-echo -n "pers_${PROFILE}_default,com.github.generic-trust-anchor-api.basic.tls" | base64 >>./client/gta-key.pem
+# b64(pers_ec_default,com.github.generic-trust-anchor-api.basic.signature)
+echo -n "pers_${PROFILE}_default,com.github.generic-trust-anchor-api.basic.signature" | base64 >>./client/gta-key.pem
 echo "-----END GTA PRIVATE KEY-----" >>./client/gta-key.pem
 
 echo "gta_identifier_assign"

--- a/provider/gtaossl-provider.c
+++ b/provider/gtaossl-provider.c
@@ -674,7 +674,7 @@ int OSSL_provider_init(
         .provider_init = gta_sw_provider_init,
         .provider_init_config = (gtaio_istream_t *)&init_config,
         .profile_info = {
-            .profile_name = "com.github.generic-trust-anchor-api.basic.tls",
+            .profile_name = "com.github.generic-trust-anchor-api.basic.signature",
             .protection_properties = {0},
             .priority = 0}};
 


### PR DESCRIPTION
<!--
Thank you for your contribution! ❤️

To help us maintain high standards of quality and consistency, please follow our Contribution Guidelines.
-->

## Motivation and Proposed Changes

<!-- Please describe your motivation and explain the changes. If applicable, link relevant issues. -->
To be more generic, we switch from the profile com.github.generic-trust-anchor-api.basic.tls to com.github.generic-trust-anchor-api.basic.signature. As the TLS profile is only an alias, it is not a functional change.

## Checklist

Before requesting a review, please ensure the following:

- [x] Commit history is clean and meaningful
- [x] License and copyright headers are present and up to date
- [x] SonarCloud report has been reviewed; no obvious improvements possible with reasonable effort
- [ ] Documentation has been updated or extended (if applicable)
- [ ] If this PR affects other repositories in the namespace, an issue has been opened and linked accordingly
