### PR TITLE
fix: macro definition for logging

### DIFF
--- a/provider/logger/gtaossl-provider-logger.h
+++ b/provider/logger/gtaossl-provider-logger.h
@@ -26,8 +26,8 @@ extern "C" {
 #define LOG_USE_STDIO 1
 
 #if LOG_USE_STDIO
-#define LOG__STDIO_FPRINTF(stream, fmt, ...) fprintf(stream, fmt, __VA_ARGS__);
-#define LOG__STDIO_FPRINTS(stream, fmt) fprintf(stream, fmt);
+#define LOG__STDIO_FPRINTF(stream, fmt, ...) fprintf(stream, fmt, __VA_ARGS__)
+#define LOG__STDIO_FPRINTS(stream, fmt) fprintf(stream, fmt)
 #else
 #define LOG__STDIO_FPRINTF(stream, fmt, ...)
 #define LOG__STDIO_FPRINTS(stream, fmt)
@@ -56,11 +56,11 @@ extern "C" {
     }
 
 #if LOG_LEVEL == LOG_LEVEL_TRACE
-#define LOG_TRACE_ARG(fmt, ...) LOG__DECL_LOGLEVELF("TRACE", fmt, __VA_ARGS__);
-#define LOG_TRACE(fmt) LOG__DECL_LOGLEVELS("TRACE", fmt);
+#define LOG_TRACE_ARG(fmt, ...) LOG__DECL_LOGLEVELF("TRACE", fmt, __VA_ARGS__)
+#define LOG_TRACE(fmt) LOG__DECL_LOGLEVELS("TRACE", fmt)
 #ifdef LOG_BYTE_ARRARY_ON
-#define LOG_TRACE_KEY_DATA_ARG(fmt, ...) printf(fmt, __VA_ARGS__);
-#define LOG_TRACE_KEY_DATA(fmt) printf(fmt);
+#define LOG_TRACE_KEY_DATA_ARG(fmt, ...) printf(fmt, __VA_ARGS__)
+#define LOG_TRACE_KEY_DATA(fmt) printf(fmt)
 #else
 #define LOG_TRACE_KEY_DATA_ARG(fmt, ...)
 #define LOG_TRACE_KEY_DATA(fmt)
@@ -73,32 +73,32 @@ extern "C" {
 #endif
 
 #if LOG_LEVEL <= LOG_LEVEL_DEBUG
-#define LOG_DEBUG_ARG(fmt, ...) LOG__DECL_LOGLEVELF("DEBUG", fmt, __VA_ARGS__);
-#define LOG_DEBUG(fmt) LOG__DECL_LOGLEVELS("DEBUG", fmt);
+#define LOG_DEBUG_ARG(fmt, ...) LOG__DECL_LOGLEVELF("DEBUG", fmt, __VA_ARGS__)
+#define LOG_DEBUG(fmt) LOG__DECL_LOGLEVELS("DEBUG", fmt)
 #else
 #define LOG_DEBUG_ARG(fmt, ...)
 #define LOG_DEBUG(fmt)
 #endif
 
 #if LOG_LEVEL <= LOG_LEVEL_INFO
-#define LOG_INFO_ARG(fmt, ...) LOG__DECL_LOGLEVELF("INFO", fmt, __VA_ARGS__);
-#define LOG_INFO(fmt) LOG__DECL_LOGLEVELS("INFO", fmt);
+#define LOG_INFO_ARG(fmt, ...) LOG__DECL_LOGLEVELF("INFO", fmt, __VA_ARGS__)
+#define LOG_INFO(fmt) LOG__DECL_LOGLEVELS("INFO", fmt)
 #else
 #define LOG_INFO_ARG(fmt, ...)
 #define LOG_INFO(fmt)
 #endif
 
 #if LOG_LEVEL <= LOG_LEVEL_WARN
-#define LOG_WARN_ARG(fmt, ...) LOG__DECL_LOGLEVELF("WARNING", fmt, __VA_ARGS__);
-#define LOG_WARN(fmt) LOG__DECL_LOGLEVELS("WARNING", fmt);
+#define LOG_WARN_ARG(fmt, ...) LOG__DECL_LOGLEVELF("WARNING", fmt, __VA_ARGS__)
+#define LOG_WARN(fmt) LOG__DECL_LOGLEVELS("WARNING", fmt)
 #else
 #define LOG_WARN_ARG(fmt, ...)
 #define LOG_WARN(fmt)
 #endif
 
 #if LOG_LEVEL <= LOG_LEVEL_ERROR
-#define LOG_ERROR_ARG(fmt, ...) LOG__DECL_LOGLEVELF("ERROR", fmt, __VA_ARGS__);
-#define LOG_ERROR(fmt) LOG__DECL_LOGLEVELS("ERROR", fmt);
+#define LOG_ERROR_ARG(fmt, ...) LOG__DECL_LOGLEVELF("ERROR", fmt, __VA_ARGS__)
+#define LOG_ERROR(fmt) LOG__DECL_LOGLEVELS("ERROR", fmt)
 #else
 #define LOG_ERROR_ARG(fmt, ...)
 #define LOG_ERROR(fmt)


### PR DESCRIPTION
<!--
Thank you for your contribution! ❤️

To help us maintain high standards of quality and consistency, please follow our Contribution Guidelines.
-->

## Motivation and Proposed Changes

<!-- Please describe your motivation and explain the changes. If applicable, link relevant issues. -->

This PR fixes the macros for logging. It removes the ";" from the macro definitions as suggested by SonarCloud [c:S1116](https://sonarcloud.io/organizations/generic-trust-anchor-api/rules?open=c%3AS1116&rule_key=c%3AS1116).

## Checklist

Before requesting a review, please ensure the following:

- [x] Commit history is clean and meaningful
- [x] License and copyright headers are present and up to date
- [x] SonarCloud report has been reviewed; no obvious improvements possible with reasonable effort
- [ ] Documentation has been updated or extended (if applicable)
- [ ] If this PR affects other repositories in the namespace, an issue has been opened and linked accordingly
