### PR TITLE
refactor: pem decoder to enumerate and return all trusted attributes of a personality

### DIFF
--- a/demo/cmp/send_kur_cmp_message.sh
+++ b/demo/cmp/send_kur_cmp_message.sh
@@ -37,7 +37,7 @@ echo ""
 export OPENSSL_CONF=../openssl_config/openssl.cnf
 
 echo "Remove old trusted certificate"
-gta-cli personality_remove_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_name="Trusted"
+gta-cli personality_remove_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_name="Insta CA cert"
 
 echo "Get Insta CA certificate"
 wget 'http://pki.certificate.fi:8081/install-ca-cert.html/ca-certificate.crt?ca-id=632&download-certificate=1' -O "$CMP_CREDENTIAL_DIR/insta.ca.crt"

--- a/demo/cmp/send_kur_cmp_message.sh
+++ b/demo/cmp/send_kur_cmp_message.sh
@@ -43,7 +43,7 @@ echo "Get Insta CA certificate"
 wget 'http://pki.certificate.fi:8081/install-ca-cert.html/ca-certificate.crt?ca-id=632&download-certificate=1' -O "$CMP_CREDENTIAL_DIR/insta.ca.crt"
 
 echo "Add trusted certificate to personality"
-gta-cli personality_add_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_type=ch.iec.30168.trustlist.certificate.self.x509 --attr_name="Trusted" --attr_val="$CMP_CREDENTIAL_DIR/insta.ca.crt"
+gta-cli personality_add_trusted_attribute --pers=CMP --prof=com.github.generic-trust-anchor-api.basic.signature --attr_type=ch.iec.30168.trustlist.certificate.trusted.x509v3 --attr_name="Insta CA cert" --attr_val="$CMP_CREDENTIAL_DIR/insta.ca.crt"
 
 echo "List the stored attributes (after the root CA install)"
 gta-cli personality_attributes_enumerate --pers=CMP

--- a/provider/algorithms/dilithium/gtaossl-provider-dilithium-keymgmt.c
+++ b/provider/algorithms/dilithium/gtaossl-provider-dilithium-keymgmt.c
@@ -304,11 +304,8 @@ static int gtaossl_provider_dilithium_keymgmt_match(const void * keydata1, const
             unsigned char obuf[SIZE_OF_GTA_O_BUFFER_FOR_DILITHIUM] = {0};
             size_t obuf_size = sizeof(obuf) - 1;
 
-            LOG_TRACE("Open output stream");
-            if (!ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size, &errinfo)) {
-                LOG_ERROR_ARG("ostream_to_buf_init failed: %lu", errinfo);
-                return NOK;
-            }
+            LOG_TRACE("Init output stream");
+            ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size);
 
             LOG_TRACE("gta_personality_enroll(...)");
             if (!gta_personality_enroll(h_ctx, (gtaio_ostream_t *)&ostream_data, &errinfo)) {
@@ -352,11 +349,6 @@ static int gtaossl_provider_dilithium_keymgmt_match(const void * keydata1, const
             pub_key_from_data_2_with_gta_api =
                 mem_dup(pub_key->public_key_data->data, (size_t)(pub_key->public_key_data->length));
             size_of_pub_key_from_data_2_with_gta_api = (size_t)(pub_key->public_key_data->length);
-
-            if (OK != ostream_to_buf_close(&ostream_data, &errinfo)) {
-                LOG_ERROR_ARG("ostream_to_buf_close failed: %lu", errinfo);
-                return NOK;
-            }
         }
 
         if (OK != gta_context_close(h_ctx, &errinfo)) {

--- a/provider/algorithms/ecdsa/gtaossl-provider-ecdsa-keymgmt.c
+++ b/provider/algorithms/ecdsa/gtaossl-provider-ecdsa-keymgmt.c
@@ -337,11 +337,8 @@ static int gtaossl_provider_ecdsa_keymgmt_match(const void * keydata1, const voi
             unsigned char obuf[SIZE_OF_GTA_O_BUFFER] = {0};
             size_t obuf_size = sizeof(obuf) - 1;
 
-            LOG_TRACE("Open output stream");
-            if (!ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size, &errinfo)) {
-                LOG_ERROR_ARG("ostream_to_buf_init failed: %lu", errinfo);
-                return NOK;
-            }
+            LOG_TRACE("Init output stream");
+            ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size);
 
             LOG_TRACE("gta_personality_enroll(...)");
             if (!gta_personality_enroll(h_ctx, (gtaio_ostream_t *)&ostream_data, &errinfo)) {
@@ -384,11 +381,6 @@ static int gtaossl_provider_ecdsa_keymgmt_match(const void * keydata1, const voi
             public_key_raw_from_keydata_2_with_gta_api =
                 mem_dup(pub_key->subjectPublicKey->data, (size_t)(pub_key->subjectPublicKey->length));
             size_of_public_key_raw_from_keydata_2_with_gta_api = (size_t)(pub_key->subjectPublicKey->length);
-
-            if (OK != ostream_to_buf_close(&ostream_data, &errinfo)) {
-                LOG_ERROR_ARG("ostream_to_buf_close failed: %lu", errinfo);
-                return NOK;
-            }
         }
 
         if (OK != gta_context_close(h_ctx, &errinfo)) {
@@ -522,11 +514,8 @@ int gtaossl_provider_ecdsa_keymgmt_export(void * keydata, int selection, OSSL_CA
             unsigned char obuf[SIZE_OF_GTA_O_BUFFER] = {0};
             size_t obuf_size = sizeof(obuf) - 1;
 
-            LOG_TRACE("Open output stream");
-            if (!ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size, &errinfo)) {
-                LOG_ERROR_ARG("ostream_to_buf_init failed: %lu", errinfo);
-                return NOK;
-            }
+            LOG_TRACE("Init output stream");
+            ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size);
 
             LOG_TRACE("gta_personality_enroll(...)");
             if (!gta_personality_enroll(h_ctx, (gtaio_ostream_t *)&ostream_data, &errinfo)) {
@@ -586,11 +575,6 @@ int gtaossl_provider_ecdsa_keymgmt_export(void * keydata, int selection, OSSL_CA
             public_key_raw_from_keydata_2_with_gta_api =
                 mem_dup(pub_key->subjectPublicKey->data, (size_t)(pub_key->subjectPublicKey->length));
             size_of_public_key_raw_from_keydata_2_with_gta_api = (size_t)(pub_key->subjectPublicKey->length);
-
-            if (OK != ostream_to_buf_close(&ostream_data, &errinfo)) {
-                LOG_ERROR_ARG("ostream_to_buf_close failed: %lu", errinfo);
-                return NOK;
-            }
         }
 
         if (OK != gta_context_close(h_ctx, &errinfo)) {

--- a/provider/algorithms/gtaossl-provider-base-decoder.h
+++ b/provider/algorithms/gtaossl-provider-base-decoder.h
@@ -26,6 +26,8 @@ struct gta_der_decoder_ctx_st {
     const OSSL_CORE_HANDLE * core;
     OSSL_LIB_CTX * libctx;
     GTA_PROVIDER_CTX * provctx;
+    gta_enum_handle_t h_persenum;
+    gta_personality_attribute_name_t next_attribute;
 };
 
 typedef struct gta_decoder_ctx_st GTA_DECODER_CTX;

--- a/provider/algorithms/gtaossl-provider-base-gta-decoder.c
+++ b/provider/algorithms/gtaossl-provider-base-gta-decoder.c
@@ -206,11 +206,8 @@ int gtaossl_provider_base_gta_decoder_decode(
         unsigned char obuf[SIZE_OF_GTA_O_BUFFER] = {0};
         size_t obuf_size = sizeof(obuf) - 1;
 
-        LOG_TRACE("Open output stream");
-        if (!ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size, &errinfo)) {
-            LOG_ERROR_ARG("ostream_to_buf_init failed: %lu", errinfo);
-            return NOK;
-        }
+        LOG_TRACE("Init output stream");
+        ostream_to_buf_init(&ostream_data, (char *)obuf, obuf_size);
 
         LOG_TRACE("Get attribute");
         if (!gta_personality_get_attribute(
@@ -228,11 +225,6 @@ int gtaossl_provider_base_gta_decoder_decode(
                 LOG_DEBUG("Skip decoder");
                 return OK;
             }
-        }
-
-        if (OK != ostream_to_buf_close(&ostream_data, &errinfo)) {
-            LOG_ERROR_ARG("ostream_to_buf_close failed: %lu", errinfo);
-            return NOK;
         }
 
         if (OK != gta_context_close(dctx->h_ctx, &errinfo)) {

--- a/provider/algorithms/gtaossl-provider-base-keymgmt.c
+++ b/provider/algorithms/gtaossl-provider-base-keymgmt.c
@@ -62,7 +62,7 @@ void * gtaossl_provider_base_keymgmt_load(const void * reference, size_t referen
     LOG_DEBUG_ARG("CALL_FUNC(%s)", __func__);
     LOG_TRACE_ARG("reference_sz: %zu", reference_sz);
 
-    const GTA_PKEY * pkey = *(GTA_PKEY **)reference;
+    GTA_PKEY * pkey = *(GTA_PKEY **)reference;
 
     LOG_TRACE_ARG("Function(%s) GTA pkey->string = %s", __func__, pkey->string);
     LOG_TRACE_ARG("Function(%s) GTA pkey->personality_name = %s", __func__, pkey->personality_name);

--- a/provider/algorithms/gtaossl-provider-base-signature.c
+++ b/provider/algorithms/gtaossl-provider-base-signature.c
@@ -205,14 +205,8 @@ int gtaossl_provider_base_signature_digest_sign(
     ostream_to_buf_t ostream_seal = {0};
 
     unsigned char gta_sig[OQS_SIG_BUFFER] = {0};
-    if (OK != istream_from_buf_init(&istream_data_to_seal, (const char *)data, datalen, &errinfo)) {
-        LOG_ERROR("istream_from_buf_init failed");
-        return NOK;
-    }
-    if (OK != ostream_to_buf_init(&ostream_seal, (char *)gta_sig, sizeof(gta_sig), &errinfo)) {
-        LOG_ERROR("ostream_to_buf_init failed");
-        return NOK;
-    }
+    istream_from_buf_init(&istream_data_to_seal, (const char *)data, datalen);
+    ostream_to_buf_init(&ostream_seal, (char *)gta_sig, sizeof(gta_sig));
 
     if (OK != gta_authenticate_data_detached(
                   sctx->h_ctx, (gtaio_istream_t *)&istream_data_to_seal, (gtaio_ostream_t *)&ostream_seal, &errinfo)) {
@@ -230,14 +224,6 @@ int gtaossl_provider_base_signature_digest_sign(
     memcpy(sig, gta_sig, ostream_seal.buf_pos);
     *siglen = ostream_seal.buf_pos;
 
-    if (OK != istream_from_buf_close(&istream_data_to_seal, &errinfo)) {
-        LOG_ERROR("istream_from_buf_close failed");
-        return NOK;
-    }
-    if (OK != ostream_to_buf_close(&ostream_seal, &errinfo)) {
-        LOG_ERROR("ostream_to_buf_close failed");
-        return NOK;
-    }
     if (OK != gta_context_close(sctx->h_ctx, &errinfo)) {
         LOG_ERROR("gta_context_close failed");
         return NOK;

--- a/provider/config/gtaossl-provider-config.h
+++ b/provider/config/gtaossl-provider-config.h
@@ -33,10 +33,12 @@ extern "C" {
 
 #define GTA_READ_BUFFER 2048
 #define GTA_READ_BUFFER_FOR_CA_CERT 4096
+#define MAXLEN_ATTRIBUTE_NAME 1000
 #define SIZE_OF_GTA_O_BUFFER 1000
 #define SIZE_OF_GTA_O_BUFFER_FOR_DILITHIUM 4000
 
 #define GTA_KEY_TYPE_ATTRIBUTE "com.github.generic-trust-anchor-api.keytype.openssl"
+#define GTA_TRUSTED_CERTIFICATE_TYPE "ch.iec.30168.trustlist.certificate.trusted.x509v3"
 
 #define PUB_KEY_BEGIN_TAG "-----BEGIN PUBLIC KEY-----\n"
 #define PUB_KEY_END_TAG "\n-----END PUBLIC KEY-----\n"

--- a/provider/gtaossl-provider.c
+++ b/provider/gtaossl-provider.c
@@ -681,9 +681,7 @@ int OSSL_provider_init(
         },
         NULL};
 
-    if (!istream_from_buf_init(&init_config, SERIALIZATION_FOLDER, sizeof(SERIALIZATION_FOLDER) - 1, &errinfo)) {
-        return clean_up(prov, ret, &errinfo);
-    }
+    istream_from_buf_init(&init_config, SERIALIZATION_FOLDER, sizeof(SERIALIZATION_FOLDER) - 1);
 
     struct gta_provider_info_t provider_info = {
         .version = 0,
@@ -705,11 +703,6 @@ int OSSL_provider_init(
     LOG_TRACE("Calling gta_register_provider");
     if (1 != gta_register_provider(prov->h_inst, &provider_info, &errinfo)) {
         LOG_ERROR("The gta_register_provider failed");
-        return clean_up(prov, ret, &errinfo);
-    }
-
-    if (!istream_from_buf_close(&init_config, &errinfo)) {
-        LOG_ERROR("The ibufstream closing failed");
         return clean_up(prov, ret, &errinfo);
     }
 

--- a/provider/stream/streams.c
+++ b/provider/stream/streams.c
@@ -17,237 +17,134 @@
 #include <string.h>
 
 /**
- * Check how many bytes are still available in the input data buffer.
- *
- * @param[in] istream: input stream
- * @param[out] len: length of available bytes
- */
-void check_available_bytes_in_input_buffer(istream_from_buf_t ** istream, size_t * len)
-{
-
-    size_t bytes_available = (*istream)->buf_size - (*istream)->buf_pos;
-
-    if (bytes_available < (*len)) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_TRACE("Write only as many bytes as requested in case more are available");
-#endif
-        (*len) = bytes_available;
-    }
-}
-
-/**
  * Read byte array data to input stream.
  */
-GTA_DEFINE_FUNCTION(
-    size_t,
-    istream_from_buf_read,
-    (istream_from_buf_t * istream, char * data, size_t len, gta_errinfo_t * p_errinfo))
+size_t istream_from_buf_read(istream_from_buf_t * istream, char * data, size_t len, gta_errinfo_t * p_errinfo)
 {
-    if (NULL == istream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Input stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return NO_SIZE_INFO;
+    /* unused */
+    (void)p_errinfo;
+
+    /* Check how many bytes are still available in data buffer */
+    size_t bytes_available = istream->buf_size - istream->buf_pos;
+    if (bytes_available < len) {
+        /* Write only as many bytes as requested in case more are available */
+        len = bytes_available;
     }
 
-    if (NULL == data) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Input data is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return NO_SIZE_INFO;
-    }
-
-    check_available_bytes_in_input_buffer(&istream, &len);
-
-#ifdef LOG_BYTE_ARRARY_ON
-    LOG_TRACE("Copy the bytes from the buffer.");
-#endif
+    /* Copy the bytes from the buffer */
     memcpy(data, &(istream->buf[istream->buf_pos]), len);
-
-#ifdef LOG_BYTE_ARRARY_ON
-    LOG_TRACE("Set new position in data buffer.");
-#endif
+    /* Set new position in data buffer */
     istream->buf_pos += len;
 
+    /* Return number of read bytes */
     return len;
 }
 
 /**
  * Check end of the input stream.
  */
-GTA_DEFINE_FUNCTION(bool, istream_from_buf_eof, (istream_from_buf_t * istream, gta_errinfo_t * p_errinfo))
+bool istream_from_buf_eof(istream_from_buf_t * istream, gta_errinfo_t * p_errinfo)
 {
-    if (NULL == istream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Input stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
+    /* unused */
+    (void)p_errinfo;
+
+    /* Return true if we are at the end of the buffer */
     return (istream->buf_pos == istream->buf_size);
 }
 
 /**
  * Initialize the input stream.
  */
-GTA_DEFINE_FUNCTION(
-    bool,
-    istream_from_buf_init,
-    (istream_from_buf_t * istream, const char * buf, size_t buf_size, gta_errinfo_t * p_errinfo))
+void istream_from_buf_init(istream_from_buf_t * istream, const char * buf, size_t buf_size)
 {
-    if (NULL == istream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Input stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
-
-    if (NULL == buf) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Input buf is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
-
     istream->read = (gtaio_stream_read_t)istream_from_buf_read;
     istream->eof = (gtaio_stream_eof_t)istream_from_buf_eof;
     istream->buf = buf;
     istream->buf_size = buf_size;
     istream->buf_pos = 0;
-
-    return true;
-}
-
-/**
- * Close the input stream.
- */
-GTA_DEFINE_FUNCTION(bool, istream_from_buf_close, (istream_from_buf_t * istream, gta_errinfo_t * p_errinfo))
-{
-    if (NULL == istream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Input stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
-
-    gta_memset(istream, sizeof(istream_from_buf_t), 0, sizeof(istream_from_buf_t));
-    return true;
 }
 
 /**
  * Finish function.
  */
-GTA_DEFINE_FUNCTION(bool, ostream_finish, (gtaio_ostream_t * ostream, gta_errinfo_t errinfo, gta_errinfo_t * p_errinfo))
+bool ostream_finish(gtaio_ostream_t * ostream, gta_errinfo_t errinfo, gta_errinfo_t * p_errinfo)
 {
+    /* unused */
+    (void)ostream;
+    (void)errinfo;
+    (void)p_errinfo;
+
     return true;
 }
 
 /**
- * Check how many bytes are still available in the output data buffer.
- *
- * @param[in] ostream: output stream
- * @param[out] len: length of available bytes
+ * Write byte to the output stream.
  */
-void check_available_bytes_in_ouput_buffer(ostream_to_buf_t ** ostream, size_t * len)
+size_t ostream_to_buf_write(ostream_to_buf_t * ostream, const char * data, size_t len, gta_errinfo_t * p_errinfo)
 {
+    /* unused */
+    (void)p_errinfo;
 
-    size_t bytes_available = (*ostream)->buf_size - (*ostream)->buf_pos;
-
-    if (bytes_available < (*len)) {
-        (*len) = bytes_available;
+    /* Check how many bytes are still available in data buffer */
+    size_t bytes_available = ostream->buf_size - ostream->buf_pos;
+    if (bytes_available < len) {
+        /* Write only as many bytes as are still available in data buffer */
+        len = bytes_available;
     }
-}
-
-/**
- * Write byte from the output stream.
- */
-GTA_DEFINE_FUNCTION(
-    size_t,
-    ostream_to_buf_write,
-    (ostream_to_buf_t * ostream, const char * data, size_t len, gta_errinfo_t * p_errinfo))
-{
-    if (NULL == ostream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Output stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return NO_SIZE_INFO;
-    }
-
-    if (NULL == data) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Data is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return NO_SIZE_INFO;
-    }
-
-    check_available_bytes_in_ouput_buffer(&ostream, &len);
-
-#ifdef LOG_BYTE_ARRARY_ON
-    LOG_TRACE("Copy the bytes from the buffer.");
-#endif
+    /* Copy the bytes to the buffer */
     memcpy(&(ostream->buf[ostream->buf_pos]), data, len);
-
-#ifdef LOG_BYTE_ARRARY_ON
-    LOG_TRACE("Set new position in data buffer.");
-#endif
+    /* Set new position in data buffer */
     ostream->buf_pos += len;
 
+    /* Return number of written bytes */
     return len;
 }
 
 /**
  * Initialize the output stream.
  */
-GTA_DEFINE_FUNCTION(
-    bool,
-    ostream_to_buf_init,
-    (ostream_to_buf_t * ostream, char * buf, size_t buf_size, gta_errinfo_t * p_errinfo))
+void ostream_to_buf_init(ostream_to_buf_t * ostream, char * buf, size_t buf_size)
 {
-    if (NULL == ostream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Output stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
-
-    if (NULL == buf) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Out buffer is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
-
     ostream->write = (gtaio_stream_write_t)ostream_to_buf_write;
     ostream->finish = ostream_finish;
     ostream->buf = buf;
     ostream->buf_size = buf_size;
     ostream->buf_pos = 0;
-
-    return true;
+    memset(buf, 0x00, buf_size);
 }
 
 /**
- * Close the output stream.
+ * Compare bytes from the output stream with stored reference.
  */
-GTA_DECLARE_FUNCTION(bool, ostream_to_buf_close, (ostream_to_buf_t * ostream, gta_errinfo_t * p_errinfo))
+size_t ocmpstream_write(ocmpstream_t * ostream, const char * data, size_t len, gta_errinfo_t * p_errinfo)
 {
-    if (NULL == ostream) {
-#ifdef LOG_BYTE_ARRARY_ON
-        LOG_ERROR("Output stream is null.");
-#endif
-        (*p_errinfo) = GTA_ERROR_PTR_INVALID;
-        return false;
-    }
+    /* unused */
+    (void)p_errinfo;
 
-    gta_memset(ostream, sizeof(ostream_to_buf_t), 0, sizeof(ostream_to_buf_t));
-    return true;
+    if (CMP_ONGOING == ostream->cmp_result) {
+        /* Check whether the current part of the string matches */
+        if (0 == strncmp(data, (ostream->buf + ostream->pos), len)) {
+            /* Check whether the end of both strings is reached */
+            if (('\0' == data[len - 1]) && ('\0' == ostream->buf[ostream->pos + len - 1])) {
+                ostream->cmp_result = CMP_EQUAL;
+            } else {
+                ostream->pos += len;
+            }
+        } else {
+            ostream->cmp_result = CMP_UNEQUAL;
+        }
+    }
+    return len;
+}
+
+/**
+ * Initialize the cmp stream.
+ */
+void ocmpstream_init(ocmpstream_t * ostream, char * buf)
+{
+    ostream->write = (gtaio_stream_write_t)ocmpstream_write;
+    ostream->finish = (gtaio_stream_finish_t)ostream_finish;
+    ostream->buf = buf;
+    ostream->pos = 0;
+    ostream->cmp_result = CMP_ONGOING;
 }

--- a/provider/stream/streams.h
+++ b/provider/stream/streams.h
@@ -50,10 +50,7 @@ typedef struct istream_from_buf {
  * @param[out] p_errinfo: error information
  * @return number of read bytes
  */
-GTA_DECLARE_FUNCTION(
-    size_t,
-    istream_from_buf_read,
-    (istream_from_buf_t * istream, char * data, size_t len, gta_errinfo_t * p_errinfo));
+size_t istream_from_buf_read(istream_from_buf_t * istream, char * data, size_t len, gta_errinfo_t * p_errinfo);
 
 /**
  * Check end of the input stream.
@@ -62,7 +59,7 @@ GTA_DECLARE_FUNCTION(
  * @param p_errinfo: error information
  * @return true if at the end of the buffer
  */
-GTA_DECLARE_FUNCTION(bool, istream_from_buf_eof, (istream_from_buf_t * istream, gta_errinfo_t * p_errinfo));
+bool istream_from_buf_eof(istream_from_buf_t * istream, gta_errinfo_t * p_errinfo);
 
 /**
  * Initialize the input stream.
@@ -70,22 +67,9 @@ GTA_DECLARE_FUNCTION(bool, istream_from_buf_eof, (istream_from_buf_t * istream, 
  * @param[out] istream: input stream
  * @param[in] buf: input buffer
  * @param[in] buf_size: size of the input buffer
- * @param[out] p_errinfo: error information
- * @return true if the stream is initialized
+ * @return void (this function cannot fail)
  */
-GTA_DECLARE_FUNCTION(
-    bool,
-    istream_from_buf_init,
-    (istream_from_buf_t * istream, const char * buf, size_t buf_size, gta_errinfo_t * p_errinfo));
-
-/**
- * Close the input stream.
- *
- * @param[out] istream: input stream
- * @param[out] p_errinfo: error information
- * @return true if the the stream is closed
- */
-GTA_DEFINE_FUNCTION(bool, istream_from_buf_close, (istream_from_buf_t * istream, gta_errinfo_t * p_errinfo));
+void istream_from_buf_init(istream_from_buf_t * istream, const char * buf, size_t buf_size);
 
 /**
  * Finish function.
@@ -95,10 +79,7 @@ GTA_DEFINE_FUNCTION(bool, istream_from_buf_close, (istream_from_buf_t * istream,
  * @param[out] p_errinfo: error information
  * @return true if the reading of stream is finished
  */
-GTA_DEFINE_FUNCTION(
-    bool,
-    ostream_finish,
-    (gtaio_ostream_t * ostream, gta_errinfo_t errinfo, gta_errinfo_t * p_errinfo));
+bool ostream_finish(gtaio_ostream_t * ostream, gta_errinfo_t errinfo, gta_errinfo_t * p_errinfo);
 
 /*
  * gtaio output stream implementation to write the output to a temporary buffer.
@@ -126,10 +107,7 @@ typedef struct ostream_to_buf {
  * @param[out] p_errinfo: error information
  * @return number of written bytes
  */
-GTA_DEFINE_FUNCTION(
-    size_t,
-    ostream_to_buf_write,
-    (ostream_to_buf_t * ostream, const char * data, size_t len, gta_errinfo_t * p_errinfo));
+size_t ostream_to_buf_write(ostream_to_buf_t * ostream, const char * data, size_t len, gta_errinfo_t * p_errinfo);
 
 /**
  * Initialize the output stream.
@@ -137,22 +115,45 @@ GTA_DEFINE_FUNCTION(
  * @param[out] ostream: output stream
  * @param[in] buf: output buffer
  * @param[in] buf_size: size of the output buffer
- * @param[out] p_errinfo: error information
- * @return true if the stream is initialized
+ * @return void (this function cannot fail)
  */
-GTA_DEFINE_FUNCTION(
-    bool,
-    ostream_to_buf_init,
-    (ostream_to_buf_t * ostream, char * buf, size_t buf_size, gta_errinfo_t * p_errinfo));
+void ostream_to_buf_init(ostream_to_buf_t * ostream, char * buf, size_t buf_size);
+
+/*
+ * gtaio output stream implementation to compare a stream output with a string.
+ */
+typedef struct ocmpstream {
+    /* public interface as defined for gtaio_ostream */
+    void * p_reserved0;
+    void * p_reserved1;
+    gtaio_stream_write_t write;
+    gtaio_stream_finish_t finish;
+
+    /* private implementation details */
+    char * buf; /* buffer holding the string to compare with the stream output */
+    size_t pos; /* current position in the buffer */
+    enum { CMP_ONGOING, CMP_EQUAL, CMP_UNEQUAL } cmp_result;
+} ocmpstream_t;
 
 /**
- * Close the output stream.
+ * Compare bytes from the output stream with stored reference.
  *
- * @param ostream: output stream
- * @param p_errinfo: error information
- * @return true if the stream is closed
+ * @param[in] ostream: output steam
+ * @param[out] data: byte array
+ * @param[out] len: length of byte array
+ * @param[out] p_errinfo: error information
+ * @return number of written bytes
  */
-GTA_DECLARE_FUNCTION(bool, ostream_to_buf_close, (ostream_to_buf_t * ostream, gta_errinfo_t * p_errinfo));
+size_t ocmpstream_write(ocmpstream_t * ostream, const char * data, size_t len, gta_errinfo_t * p_errinfo);
+
+/**
+ * Initialize the cmp stream.
+ *
+ * @param[out] ostream: output stream
+ * @param[in] ref: reference string to compare
+ * @return void (this function cannot fail)
+ */
+void ocmpstream_init(ocmpstream_t * ostream, char * ref);
 
 #ifdef __cplusplus
 }

--- a/tests/integration/test_send_kur_cmp_to_demo_ca.sh
+++ b/tests/integration/test_send_kur_cmp_to_demo_ca.sh
@@ -26,7 +26,7 @@ function test_send_kur_cmp_to_fake_ca
     assert_output_contains "CMP info: received KUP"
     assert_output_contains "CMP DEBUG: successfully validated signature-based CMP message protection using trust store"
     assert_output_contains "CMP DEBUG: validating CMP message"
-    assert_output_contains "Attribute Name:   Trusted"
+    assert_output_contains "Attribute Name:   Insta CA cert"
     assert_output_contains "Attribute Name:   Test Cert"
     return 0
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! ❤️

To help us maintain high standards of quality and consistency, please follow our Contribution Guidelines.
-->

## Motivation and Proposed Changes

<!-- Please describe your motivation and explain the changes. If applicable, link relevant issues. -->
Currently, the trusted attribute to be returned is selected by name. This PR changes this to enumerate and return all attributes of type "trusted certificate". In addition, the stream functions are refactored to be in line with the functions in the other GTA API repos.

Closes #7 and #14.

## Checklist

Before requesting a review, please ensure the following:

- [x] Commit history is clean and meaningful
- [x] License and copyright headers are present and up to date
- [x] SonarCloud report has been reviewed; no obvious improvements possible with reasonable effort
- [ ] Documentation has been updated or extended (if applicable)
- [ ] If this PR affects other repositories in the namespace, an issue has been opened and linked accordingly
